### PR TITLE
Feature/money default currency and refactor JS

### DIFF
--- a/app/assets/javascripts/administrate-field-money/application.js
+++ b/app/assets/javascripts/administrate-field-money/application.js
@@ -1,14 +1,38 @@
 //= require jquery.maskMoney.min
 
 $(function() {
-  $('.maskmoney').each(function() {
-    // Apply the mask and trigger it
-    $(this).maskMoney().trigger('mask');
+  var getUnmaskedMoneyCents,
+      updateSiblingHiddenFieldValueOf,
+      syncUnmaskedValueWithHiddenField,
+      $applyMaskMoneyTo,
+      setupMaskMoney,
+      EVENTS_TO_SYNC = 'change keyup paste';
 
-    // Sync unmasked value with hidden field
-    $(this).on('change keyup paste', function() {
-      var unmaskedMoneyCents = $(this).maskMoney('unmasked')[0] * 100;
-      $(this).siblings('[type="hidden"]').val(unmaskedMoneyCents);
-    })
-  });
+  getUnmaskedMoneyCents = function($el) {
+    return $el.maskMoney('unmasked')[0] * 100;
+  };
+
+  updateSiblingHiddenFieldValueOf = function($el, getNewValue) {
+    $el.siblings('[type="hidden"]').val(
+      getNewValue($el)
+    );
+  };
+
+  syncUnmaskedValueWithHiddenField = function() {
+    updateSiblingHiddenFieldValueOf($(this), getUnmaskedMoneyCents);
+  };
+
+  $applyMaskMoneyTo = function(el) {
+    return $(el).maskMoney().trigger('mask');
+  };
+
+  setupMaskMoney = function() {
+    $applyMaskMoneyTo(this)
+      .on(
+        EVENTS_TO_SYNC,
+        syncUnmaskedValueWithHiddenField
+      );
+  };
+
+  $('[data-maskmoney]').each(setupMaskMoney);
 });

--- a/app/views/fields/money/_form.html.erb
+++ b/app/views/fields/money/_form.html.erb
@@ -17,7 +17,11 @@ that gets submitted with the form.
   <%= f.label field.attribute %>
 </div>
 <div class="field-unit__field">
-  <%= text_field_tag field.attribute, field.data, class: 'maskmoney',
-      data: { prefix: field.symbol, thousands: field.delimiter, decimal: field.separator } %>
+  <%= text_field_tag field.attribute, field.data,
+      data: {
+        maskmoney: true,
+        thousands: field.delimiter,
+        decimal: field.separator,
+        prefix: field.symbol } %>
   <%= f.hidden_field field.attribute %>
 </div>

--- a/lib/administrate/field/money.rb
+++ b/lib/administrate/field/money.rb
@@ -5,6 +5,8 @@ require 'administrate/engine'
 module Administrate
   module Field
     class Money < Administrate::Field::Text
+      delegate :currency, to: :money
+
       class Engine < ::Rails::Engine
         Administrate::Engine.add_javascript 'administrate-field-money/application'
       end
@@ -22,15 +24,15 @@ module Administrate
       end
 
       def symbol
-        options.fetch(:symbol, money.symbol)
+        options.fetch(:symbol, currency.symbol)
       end
 
       def delimiter
-        options.fetch(:delimiter, money.delimiter)
+        options.fetch(:delimiter, currency.thousands_separator)
       end
 
       def separator
-        options.fetch(:separator, money.separator)
+        options.fetch(:separator, currency.decimal_mark)
       end
     end
   end

--- a/lib/administrate/field/money.rb
+++ b/lib/administrate/field/money.rb
@@ -18,7 +18,7 @@ module Administrate
       end
 
       def code
-        options.fetch(:code, 'USD')
+        options.fetch(:code, ::Money.default_currency.iso_code)
       end
 
       def symbol


### PR DESCRIPTION
Summary:
----------
1. Replace default hardcoded currency (USD) by Money.default_currency
2. Fix mask delimiter and separator chars using the currency info
2. Refactor JS and use a data attribute to attach the maskMoney plugin